### PR TITLE
Fix issue of profiles data while loading

### DIFF
--- a/src/pages/ProfilesList.jsx
+++ b/src/pages/ProfilesList.jsx
@@ -54,6 +54,7 @@ export default function ProfilesList() {
   const handleFilterApply = async (myfilters) => {
     try {
       setProfilesLoading(true);
+      setProfiles([])
       let queryString = "";
       Object.keys(myfilters).forEach((key) => {
         if (


### PR DESCRIPTION
The during loading time the previous profiles were shown

<img width="1427" alt="image" src="https://github.com/Parinaye/parinaye_frontend/assets/28009108/38fba1d3-4141-4e92-a37a-bc4eef7df301">


fixing this issue with this.
Where only loading bar will be shown